### PR TITLE
Clarified php CURLOPT_SSL_VERIFYPEER

### DIFF
--- a/php/persona.php
+++ b/php/persona.php
@@ -30,7 +30,7 @@ class Persona
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $postdata);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true); //If you're testing on windows localhost, set to "false"
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         $response = curl_exec($ch);
         curl_close($ch);


### PR DESCRIPTION
Clarified that you need to set CURLOPT_SSL_VERIFYPEER to false when testing on your localhost. Otherwise you get an error.